### PR TITLE
perf: バックエンドのワーカーを増やした

### DIFF
--- a/webapp/backend/src/main.rs
+++ b/webapp/backend/src/main.rs
@@ -152,7 +152,8 @@ async fn main() -> std::io::Result<()> {
             )
     })
     .bind(format!("0.0.0.0:{port}"))?
-    .workers(1)
+    // 本番環境のコア数に合わせた
+    .workers(4)
     .run()
     .await
 }


### PR DESCRIPTION
- ローカルだとコア数8の方がスコアよかったんですが、とりあえず本番環境のコア数に合わせて4にしました